### PR TITLE
Benedikt/migrate pytorch lightning

### DIFF
--- a/pcf/models/base.py
+++ b/pcf/models/base.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning import LightningModule
 from pcf.models.loss import Loss
 from pcf.utils.projection import projection
 from pcf.utils.logger import log_point_clouds, save_range_and_mask, save_point_clouds

--- a/pcf/models/base.py
+++ b/pcf/models/base.py
@@ -207,7 +207,7 @@ class BasePredictionModel(LightningModule):
 
         return loss
 
-    def test_epoch_end(self, outputs):
+    def on_test_epoch_end(self, outputs):
         # Remove first row since it was initialized with zero
         self.chamfer_distances_tensor = self.chamfer_distances_tensor[:, 1:]
         n_steps, _ = self.chamfer_distances_tensor.shape

--- a/pcf/test.py
+++ b/pcf/test.py
@@ -85,8 +85,9 @@ if __name__ == "__main__":
         logger = False
 
     trainer = Trainer(
+        accelerator="gpu",
+        devices=cfg["TRAIN"]["N_GPUS"],
         limit_test_batches=args.limit_test_batches,
-        gpus=cfg["TRAIN"]["N_GPUS"],
         logger=logger,
     )
 

--- a/pcf/train.py
+++ b/pcf/train.py
@@ -145,16 +145,16 @@ if __name__ == "__main__":
 
     ###### Trainer
     trainer = Trainer(
-        gpus=cfg["TRAIN"]["N_GPUS"],
+        accelerator="gpu",
+        devices=cfg["TRAIN"]["N_GPUS"],
         logger=tb_logger,
         accumulate_grad_batches=cfg["TRAIN"]["BATCH_ACC"],
         max_epochs=cfg["TRAIN"]["MAX_EPOCH"],
         log_every_n_steps=cfg["TRAIN"][
             "LOG_EVERY_N_STEPS"
         ],  # times accumulate_grad_batches
-        resume_from_checkpoint=resume_from_checkpoint,
         callbacks=[lr_monitor, checkpoint],
     )
 
     ###### Training
-    trainer.fit(model, data)
+    trainer.fit(model, data, ckpt_path=resume_from_checkpoint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.8"
 PyYAML = "^6.0"
 matplotlib = "^3.4.3"
 open3d = "^0.13.0"
-pytorch-lightning = "^2.1.2"
+pytorch-lightning = "^1.5.0"
 ninja = "^1.10.2"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.8"
 PyYAML = "^6.0"
 matplotlib = "^3.4.3"
 open3d = "^0.13.0"
-pytorch-lightning = "^1.5.0"
+pytorch-lightning = "^2.1.2"
 ninja = "^1.10.2"
 
 


### PR DESCRIPTION
Solves https://github.com/PRBonn/point-cloud-prediction/issues/11

The pytorch lightning API changed, this has now been updated to allow for lightning version >= 2.0.0.