### PR TITLE
Remove deprecated argument

### DIFF
--- a/pcf/models/base.py
+++ b/pcf/models/base.py
@@ -207,7 +207,7 @@ class BasePredictionModel(LightningModule):
 
         return loss
 
-    def on_test_epoch_end(self, outputs):
+    def on_test_epoch_end(self):
         # Remove first row since it was initialized with zero
         self.chamfer_distances_tensor = self.chamfer_distances_tensor[:, 1:]
         n_steps, _ = self.chamfer_distances_tensor.shape


### PR DESCRIPTION
This argument is deprecated and, anyway, not used.

Solves https://github.com/PRBonn/point-cloud-prediction/issues/13